### PR TITLE
Update sonarqube-chart-values.yaml.tpl

### DIFF
--- a/sonarqube/templates/sonarqube-chart-values.yaml.tpl
+++ b/sonarqube/templates/sonarqube-chart-values.yaml.tpl
@@ -20,6 +20,9 @@ persistence:
 
 initContainers:
   image: ${registry_name}:${registry_port}/${busybox_image_name}:${busybox_image_tag}
+  
+initSysctl:
+  image: ${registry_name}:${registry_port}/${busybox_image_name}:${busybox_image_tag}
 
 env:
  - name: SONAR_CORE_SERVERBASEURL


### PR DESCRIPTION
initSysctl container runs and tries to still pull busy box from docker hub. Causes issues when the max pull limit happens. Changed it to pull from local.