### PR TITLE
Bug with docker ps -a

### DIFF
--- a/pullthrough-registry/install.sh
+++ b/pullthrough-registry/install.sh
@@ -15,7 +15,7 @@ skip_encrypted_variables=true
 
 if [ "${pullthrough_registry_enabled}" = "true" ]; then 
 
-  if [ $( docker ps -a | grep ${pullthrough_registry_name} | wc -l ) -gt 0 ]; then
+  if [ $( docker ps | grep ${pullthrough_registry_name} | wc -l ) -gt 0 ]; then
 
     notify "pullthrough registry already exists."
 


### PR DESCRIPTION
If the registry container is stopped, doing a `docker ps -a` the container will show up on the list, therefore it thinks that the registry is running based off the conditional statement.
I think you want to just do a `docker ps` here.