### PR TITLE
fix(typo): word repetition when setting up the pullthrough_registry

### DIFF
--- a/.env
+++ b/.env
@@ -676,7 +676,7 @@ registry_name="k3d-registry.nemonik.com"
 registry_port="5000"
 
 
-## pullthrough egistry container registry
+## pullthrough container registry
 pullthrough_registry_enabled=false #true
 pullthrough_registry_port="5001"
 pullthrough_registry_name="hands-on-devops-pullthrough-registry"

--- a/README.md
+++ b/README.md
@@ -1700,7 +1700,7 @@ nvim ./..env
 then scrolling to you see
 
 ```
-## pullthrough egistry container registry
+## pullthrough container registry
 pullthrough_registry_enabled=false
 ```
 


### PR DESCRIPTION
Fixed a little typo on commentaries when setting up the `pullthrough_registry_enable` option (in both `README.md` and `.env` files).

Hope it helps ! 